### PR TITLE
import 0.1.9 from upstream

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+php-ext-snappy (0.1.9-1) unstable; urgency=medium
+
+  * Import upstream 0.1.9 
+    see https://github.com/ByteInternet/php-ext-snappy/commit/34f4a8bcd50714f62bb805f34b2b5fcdbf0f501f
+
+ -- Rick van de Loo <rick@byte.nl>  Wed, 5 Jul 2017 16:27:28 +0100
+
 php-ext-snappy (0.1.6-2) unstable; urgency=medium
 
   * Increment packaging version

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ php-ext-snappy
   <required>
    <php>
     <min>5.3.0</min>
-    <max>7.1.0</max>
+    <max>7.2.0</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>


### PR DESCRIPTION
see https://github.com/ByteInternet/php-ext-snappy/commit/34f4a8bcd50714f62bb805f34b2b5fcdbf0f501f

```
# dpkg -L php-ext-snappy 
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/php-ext-snappy
/usr/share/doc/php-ext-snappy/changelog.Debian.gz
/usr/lib
/usr/lib/php
/usr/lib/php/20131226
/usr/lib/php/20131226/snappy.so
/usr/lib/php/20160303
/usr/lib/php/20160303/snappy.so
/usr/lib/php/20121212
/usr/lib/php/20121212/snappy.so
/usr/lib/php/20151012
/usr/lib/php/20151012/snappy.so
/etc
/etc/php
/etc/php/5.6
/etc/php/5.6/mods-available
/etc/php/5.6/mods-available/snappy.ini
/etc/php/7.1
/etc/php/7.1/mods-available
/etc/php/7.1/mods-available/snappy.ini
/etc/php/5.5
/etc/php/5.5/mods-available
/etc/php/5.5/mods-available/snappy.ini
/etc/php/7.0
/etc/php/7.0/mods-available
/etc/php/7.0/mods-available/snappy.ini

root@73b5db-phpextsnappy-magweb-vgr /data/web/public # php5.5 -m | grep snap
snappy
root@73b5db-phpextsnappy-magweb-vgr /data/web/public # php5.6 -m | grep snap
snappy
root@73b5db-phpextsnappy-magweb-vgr /data/web/public # php7.0 -m | grep snap
snappy
root@73b5db-phpextsnappy-magweb-vgr /data/web/public # php7.1 -m | grep snap
snappy
```