### PR TITLE
Add php72 support to php ext snappy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+php-ext-snappy (0.1.9-2) unstable; urgency=medium
+
+  * Allow compiling for PHP 7.2
+
+ -- Rick van de Loo <rick@byte.nl>  Wed, 5 Jul 2017 16:27:28 +0100
+
 php-ext-snappy (0.1.9-1) unstable; urgency=medium
 
   * Import upstream 0.1.9 

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ php-ext-snappy
   <required>
    <php>
     <min>5.3.0</min>
-    <max>7.2.0</max>
+    <max>7.3.0</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>


### PR DESCRIPTION
```
root@73b5db-phpextsnappy-magweb-vgr /vagrant # dpkg -L php-ext-snappy | grep snappy.ini
/etc/php/7.2/mods-available/snappy.ini
/etc/php/5.6/mods-available/snappy.ini
/etc/php/5.5/mods-available/snappy.ini
/etc/php/7.1/mods-available/snappy.ini
/etc/php/7.0/mods-available/snappy.ini
root@73b5db-phpextsnappy-magweb-vgr /vagrant # php -i | grep snappy
System => Linux 73b5db-phpextsnappy-magweb-vgr 4.4.0-130-generic #156-Ubuntu SMP Thu Jun 14 08:53:28 UTC 2018 x86_64
/etc/php/7.0/cli/conf.d/20-snappy.ini,
snappy
```