### PR TITLE
add php7.3 support to php-ext-snappy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+php-ext-snappy (0.1.9-3) unstable; urgency=medium
+
+  * Allow compiling for PHP 7.3
+
+ -- Rick van de Loo <rick@byte.nl>  Wed, 5 Jul 2017 16:27:28 +0100
+
 php-ext-snappy (0.1.9-2) unstable; urgency=medium
 
   * Allow compiling for PHP 7.2

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ php-ext-snappy
   <required>
    <php>
     <min>5.3.0</min>
-    <max>7.3.0</max>
+    <max>7.4.0</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>


### PR DESCRIPTION
also see earlier https://github.com/ByteInternet/php-ext-snappy/pull/4