### PR TITLE
allow building for PHP 8.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+php-ext-snappy (20211116.075346) UNRELEASED; urgency=medium
+
+  [ Rick van de Loo ]
+  * update changelog for php8.1
+  * Bump version so we can build for php8.1
+
+ -- Hypernode team <hypernode@byte.nl>  Tue, 16 Nov 2021 07:53:46 +0000
+
 php-ext-snappy (20210611.145009) UNRELEASED; urgency=medium
 
   [ Rick van de Loo ]

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ php-ext-snappy
   <required>
    <php>
     <min>5.3.0</min>
-    <max>8.1.0</max>
+    <max>8.2.0</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>


### PR DESCRIPTION
like https://github.com/ByteInternet/php-ext-snappy/pull/7, but PHP 8.1
this time