### PR TITLE
debian: Remove php-igbinary-all-dev dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-php-ext-snappy (20240227.143750) UNRELEASED; urgency=medium
+php-ext-snappy (20240301.131722) UNRELEASED; urgency=medium
 
   [ Rick van de Loo ]
   * update changelog for php8.1
@@ -10,8 +10,9 @@ php-ext-snappy (20240227.143750) UNRELEASED; urgency=medium
   * Update mark-release.sh
   * Update php-ext-snappy-src to latest version
   * debian: Update debian files to new standards
+  * debian: Remove php-igbinary-all-dev dependency
 
- -- Hypernode team <hypernode@byte.nl>  Tue, 27 Feb 2024 14:37:51 +0100
+ -- Hypernode team <hypernode@byte.nl>  Fri, 01 Mar 2024 13:17:22 +0100
 
 php-ext-snappy (20210611.145009) UNRELEASED; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -12,12 +12,11 @@ Vcs-Git: https://github.com/ByteInternet/php-ext-snappy
 Package: php-ext-snappy
 Architecture: any
 Pre-Depends: php-common (>= 2:69~)
-Depends: php-igbinary-all-dev,
+Depends: libsnappy1v5
          ${misc:Depends},
          ${pecl:Depends},
          ${php:Depends},
-         ${shlibs:Depends},
-         libsnappy1v5
+         ${shlibs:Depends}
 Breaks: ${pecl:Breaks}
 Replaces: ${pecl:Replaces}
 Provides: ${pecl:Provides}

--- a/debian/control.in
+++ b/debian/control.in
@@ -12,12 +12,11 @@ Vcs-Git: https://github.com/ByteInternet/php-ext-snappy
 Package: php-ext-snappy
 Architecture: any
 Pre-Depends: php-common (>= 2:69~)
-Depends: php-igbinary-all-dev,
+Depends: libsnappy1v5
          ${misc:Depends},
          ${pecl:Depends},
          ${php:Depends},
-         ${shlibs:Depends},
-         libsnappy1v5
+         ${shlibs:Depends}
 Breaks: ${pecl:Breaks}
 Replaces: ${pecl:Replaces}
 Provides: ${pecl:Provides}


### PR DESCRIPTION
Not sure why this was in there, but looks like a copy paste error.
Anyways, on bookworm this causes all PHP versions to be installed, which
is not ideal.